### PR TITLE
Delete old, unused labels

### DIFF
--- a/lib/delete-old-unused-labels.js
+++ b/lib/delete-old-unused-labels.js
@@ -1,46 +1,37 @@
 const labelOfTheDay = require('./label-of-the-day')
 const pullsWithLabel = require('./pulls-with-label')
 
-// - Get all labels for repo
-// - Filter repo labels down to those beginning with "merge-" and
-//   that are < today's label
-// - Get open issues for these filtered labels
-// - Filter labels down to those with 0 open issues
-// - Delete these filtered labels
-
-// TODO: add tests
 module.exports = async function ({ github, owner, repo, log }) {
   const todaysLabelName = labelOfTheDay()
   const labels = await repoLabels({ github, owner, repo, log })
   const oldMergeLabels = (labels || []).filter((label) => (
-    label.data.name.startsWith('merge-') && label.data.name < todaysLabelName
+    label.name.startsWith('merge-') && label.name < todaysLabelName
   ))
 
   const oldMergeLabelPulls = await Promise.all(oldMergeLabels.map((label) => {
-    return pullsWithLabel({ label, github, owner, repo, log })
+    return pullsWithLabel({ labelName: label.name, github, owner, repo, log })
   }))
 
   const oldUnusedMergeLabels = oldMergeLabels.filter((label, index) => {
-    const pulls = oldMergeLabelPulls[index]
+    const pulls = oldMergeLabelPulls[index].data
     return (!pulls || !pulls.length)
   })
 
   return Promise.all(oldUnusedMergeLabels.map((label) => {
-    return deleteLabel({ label, github, owner, repo, log })
+    return deleteLabel({ labelName: label.name, github, owner, repo, log })
   }))
 }
 
-// TODO: handle pagination
 function repoLabels ({ github, owner, repo, log }) {
   log.info(`Listing all labels for ${owner}/${repo}`)
-  return github.issues.listLabelsForRepo({
+  return github.paginate(github.issues.listLabelsForRepo.endpoint.merge({
     owner, repo
-  }).catch(() => { log.info('Error fetching labels') })
+  })).catch(() => { log.info('Error fetching labels') })
 }
 
-function deleteLabel ({ label, github, owner, repo, log }) {
-  log.info(`Deleting label ${label.data.name}`)
+function deleteLabel ({ labelName, github, owner, repo, log }) {
+  log.info(`Deleting label ${labelName}`)
   return github.issues.deleteLabel({
-    owner, repo, name: label.data.name
-  }).catch(() => { log.info(`Deletion of label ${label.data.name} failed`) })
+    owner, repo, name: labelName
+  }).catch(() => { log.info(`Deletion of label ${labelName} failed`) })
 }

--- a/lib/delete-old-unused-labels.js
+++ b/lib/delete-old-unused-labels.js
@@ -1,0 +1,53 @@
+const labelOfTheDay = require('./label-of-the-day')
+
+// - Get all labels for repo
+// - Filter repo labels down to those beginning with "merge-" and
+//   that are < today's label
+// - Get open issues for these filtered labels
+// - Filter labels down to those with 0 open issues
+// - Delete these filtered labels
+
+// TODO: add tests
+module.exports = async function ({ github, owner, repo, log }) {
+  const todaysLabelName = labelOfTheDay()
+  const labels = await repoLabels({ github, owner, repo, log })
+  const oldMergeLabels = labels.filter((label) => (
+    label.data.name.startsWith('merge-') && label.data.name < todaysLabelName
+  ))
+
+  const oldMergeLabelPulls = await Promise.all(oldMergeLabels.map((label) => {
+    return pullsWithLabel({ label, github, owner, repo, log })
+  }))
+
+  const oldUnusedMergeLabels = oldMergeLabels.filter((label, index) => {
+    const pulls = oldMergeLabelPulls[index]
+    return (!pulls || !pulls.length)
+  })
+
+  return Promise.all(oldUnusedMergeLabels.map((label) => {
+    return deleteLabel({ label, github, owner, repo, log })
+  }))
+}
+
+// TODO: handle pagination
+function repoLabels ({ github, owner, repo, log }) {
+  log.info(`Listing all labels for ${owner}/${repo}`)
+  return github.issues.listLabelsForRepo({
+    owner, repo
+  }).catch(() => { log.info('Error fetching labels') })
+}
+
+// TODO: extract, this is duplicated in merge-scheduled-posts
+function pullsWithLabel ({ label, github, owner, repo, log }) {
+  log.info(`Searching for PRs labeled ${label.data.name}`)
+  return github.issues.listForRepo({
+    owner, repo, labels: label.data.name, state: 'open'
+  }).catch(() => { log.info('No open PRs found') })
+}
+
+function deleteLabel ({ label, github, owner, repo, log }) {
+  log.info(`Deleting label ${label.data.name}`)
+  return github.issues.deleteLabel({
+    owner, repo, name: label.data.name
+  }).catch(() => { log.info(`Deletion of label ${label.data.name} failed`) })
+}

--- a/lib/delete-old-unused-labels.js
+++ b/lib/delete-old-unused-labels.js
@@ -11,7 +11,7 @@ const labelOfTheDay = require('./label-of-the-day')
 module.exports = async function ({ github, owner, repo, log }) {
   const todaysLabelName = labelOfTheDay()
   const labels = await repoLabels({ github, owner, repo, log })
-  const oldMergeLabels = labels.filter((label) => (
+  const oldMergeLabels = (labels || []).filter((label) => (
     label.data.name.startsWith('merge-') && label.data.name < todaysLabelName
   ))
 

--- a/lib/delete-old-unused-labels.js
+++ b/lib/delete-old-unused-labels.js
@@ -1,4 +1,5 @@
 const labelOfTheDay = require('./label-of-the-day')
+const pullsWithLabel = require('./pulls-with-label')
 
 // - Get all labels for repo
 // - Filter repo labels down to those beginning with "merge-" and
@@ -35,14 +36,6 @@ function repoLabels ({ github, owner, repo, log }) {
   return github.issues.listLabelsForRepo({
     owner, repo
   }).catch(() => { log.info('Error fetching labels') })
-}
-
-// TODO: extract, this is duplicated in merge-scheduled-posts
-function pullsWithLabel ({ label, github, owner, repo, log }) {
-  log.info(`Searching for PRs labeled ${label.data.name}`)
-  return github.issues.listForRepo({
-    owner, repo, labels: label.data.name, state: 'open'
-  }).catch(() => { log.info('No open PRs found') })
 }
 
 function deleteLabel ({ label, github, owner, repo, log }) {

--- a/lib/merge-scheduled-posts.js
+++ b/lib/merge-scheduled-posts.js
@@ -1,5 +1,6 @@
 const labelOfTheDay = require('./label-of-the-day')
 const handleMergeFailure = require('./handle-merge-failure')
+const pullsWithLabel = require('./pulls-with-label')
 
 module.exports = async function ({ github, owner, repo, log }) {
   const label = await findTodaysLabel({ github, owner, repo, log })
@@ -17,13 +18,6 @@ function findTodaysLabel ({ github, owner, repo, log }) {
   return github.issues.getLabel({
     owner, repo, name: labelName
   }).catch(() => { log.info(`No label named ${labelName}`) })
-}
-
-function pullsWithLabel ({ label, github, owner, repo, log }) {
-  log.info(`Searching for PRs labeled ${label.name}`)
-  return github.issues.listForRepo({
-    owner, repo, labels: label.data.name, state: 'open'
-  }).catch(() => { log.info('No open PRs found') })
 }
 
 async function mergePull ({ pull, github, owner, repo, log }) {

--- a/lib/merge-scheduled-posts.js
+++ b/lib/merge-scheduled-posts.js
@@ -5,7 +5,13 @@ const pullsWithLabel = require('./pulls-with-label')
 module.exports = async function ({ github, owner, repo, log }) {
   const label = await findTodaysLabel({ github, owner, repo, log })
   if (label) {
-    const pulls = await pullsWithLabel({ label, github, owner, repo, log })
+    const pulls = await pullsWithLabel({
+      labelName: label.data.name,
+      github,
+      owner,
+      repo,
+      log
+    })
     await Promise.all(pulls.data.map(async pull => {
       return mergePull({ pull, github, owner, repo, log })
     }))

--- a/lib/pulls-with-label.js
+++ b/lib/pulls-with-label.js
@@ -1,6 +1,6 @@
-module.exports = async function pullsWithLabel ({ label, github, owner, repo, log }) {
-  log.info(`Searching for PRs labeled ${label.name}`)
+module.exports = async function pullsWithLabel ({ labelName, github, owner, repo, log }) {
+  log.info(`Searching for PRs labeled ${labelName}`)
   return github.issues.listForRepo({
-    owner, repo, labels: label.data.name, state: 'open'
+    owner, repo, labels: labelName, state: 'open'
   }).catch(() => { log.info('No open PRs found') })
 }

--- a/lib/pulls-with-label.js
+++ b/lib/pulls-with-label.js
@@ -1,0 +1,6 @@
+module.exports = async function pullsWithLabel ({ label, github, owner, repo, log }) {
+  log.info(`Searching for PRs labeled ${label.name}`)
+  return github.issues.listForRepo({
+    owner, repo, labels: label.data.name, state: 'open'
+  }).catch(() => { log.info('No open PRs found') })
+}

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,5 +1,9 @@
+const deleteOldUnusedLabels = require('./delete-old-unused-labels')
 const mergeScheduledPosts = require('./merge-scheduled-posts')
 
 module.exports = function ({ github, owner, repo, log }) {
-  return mergeScheduledPosts({ github, owner, repo, log })
+  return Promise.all([
+    deleteOldUnusedLabels({ github, owner, repo, log }),
+    mergeScheduledPosts({ github, owner, repo, log })
+  ])
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,82 +18,146 @@ module.exports = {
     }))
   },
 
-  async 'does nothing when no label is found' () {
-    api.get(`/repos/fake/stuff/labels/${label}`)
-      .reply(404, {
-        message: 'Not Found',
-        documentation_url: 'https://developer.github.com/v3/issues/labels/#get-a-single-label'
-      })
+  'merge-scheduled-posts': {
+    async 'does nothing when no label is found' () {
+      api.get(`/repos/fake/stuff/labels/${label}`)
+        .reply(404, {
+          message: 'Not Found',
+          documentation_url: 'https://developer.github.com/v3/issues/labels/#get-a-single-label'
+        })
 
-    await fauxbot.trigger()
+      await fauxbot.trigger()
+    },
+
+    async 'does nothing when label is found but no pulls are open' () {
+      api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': label, 'state': 'open' })
+        .reply(200, [])
+
+      await fauxbot.trigger()
+    },
+
+    async 'does nothing when `merge-failed` label is applied' () {
+      api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': label, 'state': 'open' })
+        .reply(200, [{
+          url: 'fake pull url',
+          number: 999,
+          labels: [{ name: label }, { name: 'merge-failed' }],
+          state: 'open'
+        }])
+
+      await fauxbot.trigger()
+    },
+
+    async 'merges PR when labeled, open, and mergeable' () {
+      api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': label, 'state': 'open' })
+        .reply(200, [{
+          url: 'fake pull url',
+          number: 999,
+          labels: [{ name: label }],
+          state: 'open'
+        }])
+
+      api.put('/repos/fake/stuff/pulls/999/merge').reply(200)
+
+      await fauxbot.trigger()
+    },
+
+    async 'leaves a comment when a PR is not mergeable & labels merge-failed' () {
+      api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': label, 'state': 'open' })
+        .reply(200, [{ number: 999, labels: [] }])
+
+      api.put('/repos/fake/stuff/pulls/999/merge')
+        .reply(405, { 'message': 'Pull Request is not mergeable' })
+
+      api.get('/repos/fake/stuff/labels/merge-failed').reply(404)
+
+      api.post('/repos/fake/stuff/labels', {
+        name: 'merge-failed',
+        color: 'cc0000'
+      }).reply(201, { name: 'merge-failed' })
+
+      api.post('/repos/fake/stuff/issues/999/labels', { labels: ['merge-failed'] })
+        .reply(200)
+
+      api.post('/repos/fake/stuff/issues/999/comments', {
+        body: 'Failed to automatically merge with error: **Pull Request is not mergeable**'
+      }).reply(201)
+
+      await fauxbot.trigger()
+    }
   },
 
-  async 'does nothing when label is found but no pulls are open' () {
-    api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+  'delete-old-unused-labels': {
+    async 'does nothing when there are no old merge labels' () {
+      api.get('/repos/fake/stuff/labels')
+        .reply(200, [
+          { name: 'merge-failed' },
+          { name: 'merge-2100-01-01' },
+          { name: 'some other label' }
+        ])
 
-    api.get('/repos/fake/stuff/issues')
-      .query({ 'labels': label, 'state': 'open' })
-      .reply(200, [])
+      await fauxbot.trigger()
+    },
+    async 'does nothing when old merge labels are applied to open PRs' () {
+      const oldLabel = 'merge-2003-03-03'
 
-    await fauxbot.trigger()
-  },
+      api.get('/repos/fake/stuff/labels')
+        .reply(200, [{ name: oldLabel }])
 
-  async 'does nothing when `merge-failed` label is applied' () {
-    api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': oldLabel, 'state': 'open' })
+        .reply(200, [{ number: 999, labels: [] }])
 
-    api.get('/repos/fake/stuff/issues')
-      .query({ 'labels': label, 'state': 'open' })
-      .reply(200, [{
-        url: 'fake pull url',
-        number: 999,
-        labels: [{ name: label }, { name: 'merge-failed' }],
-        state: 'open'
-      }])
+      await fauxbot.trigger()
+    },
+    async 'deletes old merge labels that have no open PRs' () {
+      api.get('/repos/fake/stuff/labels')
+        .reply(
+          200,
+          [{ name: 'merge-2003-03-03' }],
+          { Link: '<https://api.github.com/repos/fake/stuff/labels?page=2>; rel="next", <https://api.github.com/repos/fake/stuff/labels?page=3>; rel="last"' }
+        )
+      api.get('/repos/fake/stuff/labels?page=2')
+        .reply(
+          200,
+          [{ name: 'merge-2003-03-04' }],
+          { Link: '<https://api.github.com/repos/fake/stuff/labels?page=1>; rel="prev", <https://api.github.com/repos/fake/stuff/labels?page=3>; rel="next", <https://api.github.com/repos/fake/stuff/labels?page=3>; rel="last", <https://api.github.com/repos/fake/stuff/labels?page=1>; rel="first"' }
+        )
+      api.get('/repos/fake/stuff/labels?page=3')
+        .reply(
+          200,
+          [{ name: 'merge-2003-03-05' }],
+          { Link: '<https://api.github.com/repos/fake/stuff/labels?page=2>; rel="prev", <https://api.github.com/repos/fake/stuff/labels?page=1>; rel="first"' }
+        )
 
-    await fauxbot.trigger()
-  },
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': 'merge-2003-03-03', 'state': 'open' })
+        .reply(200, [])
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': 'merge-2003-03-04', 'state': 'open' })
+        .reply(200, [{ number: 999, labels: [] }])
+      api.get('/repos/fake/stuff/issues')
+        .query({ 'labels': 'merge-2003-03-05', 'state': 'open' })
+        .reply(200, [])
 
-  async 'merges PR when labeled, open, and mergeable' () {
-    api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
+      api.delete('/repos/fake/stuff/labels/merge-2003-03-03')
+        .reply(204)
+      api.delete('/repos/fake/stuff/labels/merge-2003-03-05')
+        .reply(204)
 
-    api.get('/repos/fake/stuff/issues')
-      .query({ 'labels': label, 'state': 'open' })
-      .reply(200, [{
-        url: 'fake pull url',
-        number: 999,
-        labels: [{ name: label }],
-        state: 'open'
-      }])
-
-    api.put('/repos/fake/stuff/pulls/999/merge').reply(200)
-
-    await fauxbot.trigger()
-  },
-
-  async 'leaves a comment when a PR is not mergeable & labels merge-failed' () {
-    api.get(`/repos/fake/stuff/labels/${label}`).reply(200, { name: label })
-
-    api.get('/repos/fake/stuff/issues')
-      .query({ 'labels': label, 'state': 'open' })
-      .reply(200, [{ number: 999, labels: [] }])
-
-    api.put('/repos/fake/stuff/pulls/999/merge')
-      .reply(405, { 'message': 'Pull Request is not mergeable' })
-
-    api.get('/repos/fake/stuff/labels/merge-failed').reply(404)
-
-    api.post('/repos/fake/stuff/labels', {
-      name: 'merge-failed',
-      color: 'cc0000'
-    }).reply(201, { name: 'merge-failed' })
-
-    api.post('/repos/fake/stuff/issues/999/labels', { labels: ['merge-failed'] })
-      .reply(200)
-
-    api.post('/repos/fake/stuff/issues/999/comments', {
-      body: 'Failed to automatically merge with error: **Pull Request is not mergeable**'
-    }).reply(201)
-
-    await fauxbot.trigger()
+      await fauxbot.trigger()
+    }
   }
 }


### PR DESCRIPTION
Goes in the direction of fixing https://github.com/testdouble/scheduled-merge/issues/6.

All the code I've written here is completely untested (not even manually) but is at least in the right direction, I think.

Some thoughts about moving this forward:
* The current tests are (understandably) heavily focused on the merge side of things and very end-to-end. I could try adding enough `nock`ing to the existing tests to make them pass with old label deletion in place, and then add new tests that focus on old label deletion? Or maybe it makes sense to split up the tests and focus separately on merging PRs and deleting old labels?
* `mergeScheduledPosts` and `deleteOldUnusedLabels` both need `pullsWithLabel`. Like with the tests, I could go the minimal route (extract `pullsWithLabel` to its own file). Or I could go further and refactor several of the GitHub-focused functions into their own class/factory function (which would reduce the `github, owner, repo, log` repetition).

After writing this all out, maybe the minimal approach makes sense to start, and then I can take another look after that to see what refactoring makes sense, if any. I'm gonna leave my thoughts up there for context though.

@searls, I'm interested if you have any preferences/thoughts here.